### PR TITLE
Fix XPath typo incompatible with Rexml 3.2.5

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -802,7 +802,7 @@ module OneLogin
         # otherwise, review if the decrypted assertion contains a signature
         sig_elements = REXML::XPath.match(
           document,
-          "/p:Response[@ID=$id]/ds:Signature]",
+          "/p:Response[@ID=$id]/ds:Signature"
           { "p" => PROTOCOL, "ds" => DSIG },
           { 'id' => document.signed_element_id }
         )


### PR DESCRIPTION
Fix applied from original branch:

https://github.com/onelogin/ruby-saml/commit/b40edbf27c038b523aa7ea6b26b1144ed0e0ef53